### PR TITLE
Two fixes to work with bioconda containers

### DIFF
--- a/docker2singularity.sh
+++ b/docker2singularity.sh
@@ -146,12 +146,12 @@ singularity exec --writable --contain $new_container_name /bin/sh -c "mkdir -p m
 # making sure that any user can read and execute everything in the container
 echo "(7/9) Fixing permissions..."
 singularity exec --writable --contain $new_container_name /bin/sh -c "find /* -maxdepth 0 -not -path '/dev*' -not -path '/proc*' -not -path '/sys*' -exec chmod a+r -R '{}' \;"
-grep -q Buildroot /etc/issue
-if [[ $? -eq 0 ]] ; then
+if grep -q Buildroot /etc/issue  ; then
     # we're running on a Builroot container and need to use Busybox's find
     echo "We're running on BusyBox/Buildroot"
     singularity exec --writable --contain $new_container_name /bin/sh -c "find / -type f -or -type d -perm -u+x,o-x -not -path '/dev*' -not -path '/proc*' -not -path '/sys*' -exec chmod a+x '{}' \;"
 else 
+    echo "We're not running on BusyBox/Buildroot"
     singularity exec --writable --contain $new_container_name /bin/sh -c "find / -executable -perm -u+x,o-x -not -path '/dev*' -not -path '/proc*' -not -path '/sys*' -exec chmod a+x '{}' \;"
 fi 
 


### PR DESCRIPTION
The containers built for bioconda recipes are hosted on quay.io and use a 
Busybox based Buildroot as an underlying environment, thus providing
a subtly different find command. This patch makes docker2singularity
work with such containers.

* Replace multiple / in container name, not just the first one
  This makes quay.io containers work
* Check for buildroot environment and adjust find appropriately