### PR TITLE
ref: remove leading spaces in `docker run` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ Are you developing Docker images and you would like to run them on an HPC cluste
 
 No need to download anything from this repository! Simply type:
 
-     docker run \        
-     -v /var/run/docker.sock:/var/run/docker.sock \
-     -v D:\host\path\where\to\output\singularity\image:/output \
-     --privileged -t --rm \
-     singularityware/docker2singularity \            
-     ubuntu:14.04
+```
+docker run \
+-v /var/run/docker.sock:/var/run/docker.sock \
+-v D:\host\path\where\to\output\singularity\image:/output \
+--privileged -t --rm \
+singularityware/docker2singularity \
+ubuntu:14.04
+```
 
 Replace `D:\host\path\where\to\output\singularity\image` with a path on the host filesystem where your Singularity image will be created. Replace `ubuntu:14.04` with the docker image name you wish to convert (it will be pulled from Docker Hub if it does not exist on your host system).
 


### PR DESCRIPTION
Leading spaces in the `docker run` command prevented successful copy+paste into terminal.