### PR TITLE
Update of docker2singularity to 3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,55 @@
-FROM docker:1.13
+FROM golang:1.10.2-alpine as base
 
-RUN apk add --update automake libtool libarchive libarchive-dev python m4 autoconf alpine-sdk linux-headers && \
-    wget -qO- https://github.com/singularityware/singularity/releases/download/2.6.0/singularity-2.6.0.tar.gz | tar zxv && \
-    cd singularity-2.6.0 && ./autogen.sh && ./configure --prefix=/usr/local && make && make install && \
-    cd ../ && rm -rf singularity-2.6 && \
-    apk del automake libtool m4 autoconf alpine-sdk linux-headers
+################################################################################
+#
+# Copyright (C) 2019 Vanessa Sochat.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+################################################################################
 
-RUN mkdir -p /usr/local/var/singularity/mnt
+FROM docker:18.09
+COPY --from=base /go /go
+COPY --from=base /usr/local/go /usr/local/go
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOLANG_VERSION 1.12.5
 
-RUN apk add e2fsprogs bash tar rsync squashfs-tools
+RUN apk update && \
+    apk add --virtual automake build-base linux-headers libffi-dev
+RUN apk add --no-cache bash git openssh gcc squashfs-tools sudo libtool gawk ca-certificates libseccomp
+RUN apk add --no-cache linux-headers build-base openssl-dev util-linux util-linux-dev python rsync
+
+LABEL Maintainer vsochat@stanford.edu
+RUN mkdir -p /usr/local/var/singularity/mnt && \
+    mkdir -p $GOPATH/src/github.com/sylabs && \
+    cd $GOPATH/src/github.com/sylabs && \
+    wget -qO- https://github.com/sylabs/singularity/releases/download/v3.1.1/singularity-3.1.1.tar.gz | \
+    tar xzv && \
+    cd singularity && \
+    go get -u -v github.com/golang/dep/cmd/dep && \
+    ./mconfig -p /usr/local/singularity && \
+    make -C builddir && \
+    make -C builddir install
+
+# See https://docs.docker.com/develop/develop-images/multistage-build/
+# for more information on multi-stage builds.
+
+ENV PATH="/usr/local/singularity/bin:$PATH"
 ADD docker2singularity.sh /docker2singularity.sh
+ADD addLabel.py /addLabel.py
+ADD scripts /scripts
 RUN chmod a+x docker2singularity.sh
 
 ENTRYPOINT ["docker-entrypoint.sh", "/docker2singularity.sh"]

--- a/addLabel.py
+++ b/addLabel.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+
+'''
+
+add.py: wrapper for "add" of a key to a json file for
+        Singularity Hub command line tool.
+
+This function takes input arguments of the following:
+
+   --key: should be the key to lookup from the json file
+   --value: the value to add to the key
+   --file: should be the json file to read
+
+Copyright (c) 2019, Vanessa Sochat. All rights reserved.
+
+'''
+
+import sys
+import os
+import json
+import argparse
+
+def get_parser():
+
+    parser = argparse.ArgumentParser(description="GET key from json")
+
+    parser.add_argument("--key",
+                       dest='key',
+                       help="key to add to json",
+                       type=str,
+                       default=None)
+
+    parser.add_argument("--value",
+                       dest='value',
+                       help="value to add to the json",
+                       type=str,
+                       default=None)
+
+    parser.add_argument("--file",
+                       dest='file',
+                       help="Path to json file to add to",
+                       type=str,
+                       default=None)
+
+    parser.add_argument('-f', dest="force",
+                       help="force add (overwrite if exists)",
+                       default=False, action='store_true')
+
+    parser.add_argument('--quiet', dest="quiet",
+                       help="do not display debug",
+                       default=False, action='store_true')
+
+    return parser
+
+
+def write_json(json_obj, filename, mode="w", print_pretty=True):
+    '''write_json will (optionally,pretty print) a json object to file
+    '''
+    bot.verbose2("Writing json file %s with mode %s." % (filename, mode))
+    with open(filename, mode) as filey:
+        if print_pretty is True:
+            filey.writelines(print_json(json_obj))
+        else:
+            filey.writelines(json.dumps(json_obj))
+    return filename
+
+
+def read_json(filename, mode='r'):
+    '''read_json reads in a json file and returns
+    the data structure as dict.
+    '''
+    with open(filename, mode) as filey:
+        data = json.load(filey)
+    return data
+
+
+def ADD(key, value, jsonfile, force=False, quiet=False):
+    '''ADD will write or update a key in a json file
+    '''
+
+    # Check that key is not empty
+    if key.strip() in ['#', '', None]:
+        bot.verbose('Empty key %s, skipping' % key)
+        sys.exit(0)
+
+    key = format_keyname(key)
+    print("Adding label: '%s' = '%s'" % (key, value))
+    print("ADD %s from %s" % (key, jsonfile))
+
+    if os.path.exists(jsonfile):
+        contents = read_json(jsonfile)
+        if key in contents:
+            msg = 'Warning, %s is already set. ' % key
+            msg += 'Overwrite is set to %s' % force
+            if not quiet:
+                print(msg)
+            if force is True:
+                contents[key] = value
+            else:
+                msg = '%s found in %s ' % (key, jsonfile)
+                msg += 'and overwrite set to %s.' % force
+                print(msg)
+                sys.exit(1)
+        else:
+            contents[key] = value
+    else:
+        contents = {key: value}
+
+    print('%s is %s' % (key, value))
+    write_json(contents, jsonfile)
+    return value
+
+
+def main():
+
+    parser = get_parser()
+
+    try:
+        (args, options) = parser.parse_args()
+    except Exception:
+        sys.exit(0)
+
+    if args.key is not None and args.file is not None:
+        if args.value is not None:
+
+            value = ADD(key=args.key,
+                        value=args.value,
+                        jsonfile=args.file,
+                        force=args.force,
+                        quiet=args.quiet)
+
+    else:
+        bot.error("--key and --file and --value must be defined for ADD.")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/actions/exec
+++ b/scripts/actions/exec
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+exec "$@"

--- a/scripts/actions/run
+++ b/scripts/actions/run
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -n "${SINGULARITY_APPNAME:-}"; then
+
+    if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript"; then
+        exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/runscript" "$@"
+    else
+        echo "No Singularity runscript for contained app: ${SINGULARITY_APPNAME:-}"
+        exit 1
+    fi
+
+elif test -x "/.singularity.d/runscript"; then
+    exec "/.singularity.d/runscript" "$@"
+else
+    echo "No Singularity runscript found, executing /bin/sh"
+    exec /bin/sh "$@"
+fi

--- a/scripts/actions/shell
+++ b/scripts/actions/shell
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -n "$SINGULARITY_SHELL" -a -x "$SINGULARITY_SHELL"; then
+    exec $SINGULARITY_SHELL "$@"
+
+    echo "ERROR: Failed running shell as defined by '\$SINGULARITY_SHELL'" 1>&2
+    exit 1
+
+elif test -x /bin/bash; then
+    SHELL=/bin/bash
+    PS1="Singularity $SINGULARITY_NAME:\\w> "
+    export SHELL PS1
+    exec /bin/bash --norc "$@"
+elif test -x /bin/sh; then
+    SHELL=/bin/sh
+    export SHELL
+    exec /bin/sh "$@"
+else
+    echo "ERROR: /bin/sh does not exist in container" 1>&2
+fi
+exit 1

--- a/scripts/actions/start
+++ b/scripts/actions/start
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -x "/.singularity.d/startscript"; then
+    exec "/.singularity.d/startscript" "$@"
+fi

--- a/scripts/actions/test
+++ b/scripts/actions/test
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+
+if test -n "${SINGULARITY_APPNAME:-}"; then
+
+    if test -x "/scif/apps/${SINGULARITY_APPNAME:-}/scif/test"; then
+        exec "/scif/apps/${SINGULARITY_APPNAME:-}/scif/test" "$@"
+    else
+        echo "No Singularity tests for contained app: ${SINGULARITY_APPNAME:-}"
+        exit 1
+    fi
+elif test -x "/.singularity.d/test"; then
+    exec "/.singularity.d/test" "$@"
+else
+    echo "No Singularity container test found, executing /bin/sh -c true"
+    exec /bin/sh -c true
+fi

--- a/scripts/env/01-base.sh
+++ b/scripts/env/01-base.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# 
+# Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
+#
+# Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
+# 
+# Copyright (c) 2016-2017, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+# 
+# This software is licensed under a customized 3-clause BSD license.  Please
+# consult LICENSE.md file distributed with the sources of this project regarding
+# your rights to use or distribute this software.
+# 
+# NOTICE.  This Software was developed under funding from the U.S. Department of
+# Energy and the U.S. Government consequently retains certain rights. As such,
+# the U.S. Government has been granted for itself and others acting on its
+# behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+# to reproduce, distribute copies to the public, prepare derivative works, and
+# perform publicly and display publicly, and to permit other to do so.
+# 
+# 
+
+

--- a/scripts/env/10-docker2singularity.sh
+++ b/scripts/env/10-docker2singularity.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/scripts/env/90-environment.sh
+++ b/scripts/env/90-environment.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+#Custom environment shell code should follow
+

--- a/scripts/env/95-apps.sh
+++ b/scripts/env/95-apps.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+# Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
+#
+# See the COPYRIGHT.md file at the top-level directory of this distribution and at
+# https://github.com/sylabs/singularity/blob/master/COPYRIGHT.md.
+#
+# This file is part of the Singularity Linux container project. It is subject to the license
+# terms in the LICENSE.md file found in the top-level directory of this distribution and
+# at https://github.com/sylabs/singularity/blob/master/LICENSE.md. No part
+# of Singularity, including this file, may be copied, modified, propagated, or distributed
+# except according to the terms contained in the LICENSE.md file.
+
+
+if test -n "${SINGULARITY_APPNAME:-}"; then
+
+    # The active app should be exported
+    export SINGULARITY_APPNAME
+
+    if test -d "/scif/apps/${SINGULARITY_APPNAME:-}/"; then
+        SCIF_APPS="/scif/apps"
+        SCIF_APPROOT="/scif/apps/${SINGULARITY_APPNAME:-}"
+        export SCIF_APPROOT SCIF_APPS
+        PATH="/scif/apps/${SINGULARITY_APPNAME:-}:$PATH"
+
+        # Automatically add application bin to path
+        if test -d "/scif/apps/${SINGULARITY_APPNAME:-}/bin"; then
+            PATH="/scif/apps/${SINGULARITY_APPNAME:-}/bin:$PATH"
+        fi
+
+        # Automatically add application lib to LD_LIBRARY_PATH
+        if test -d "/scif/apps/${SINGULARITY_APPNAME:-}/lib"; then
+            LD_LIBRARY_PATH="/scif/apps/${SINGULARITY_APPNAME:-}/lib:$LD_LIBRARY_PATH"
+            export LD_LIBRARY_PATH
+        fi
+
+        # Automatically source environment
+        if [ -f "/scif/apps/${SINGULARITY_APPNAME:-}/scif/env/01-base.sh" ]; then
+            . "/scif/apps/${SINGULARITY_APPNAME:-}/scif/env/01-base.sh"
+        fi
+        if [ -f "/scif/apps/${SINGULARITY_APPNAME:-}/scif/env/90-environment.sh" ]; then
+            . "/scif/apps/${SINGULARITY_APPNAME:-}/scif/env/90-environment.sh"
+        fi
+
+        export PATH
+    else
+        echo "Could not locate the container application: ${SINGULARITY_APPNAME}"
+        exit 1
+    fi
+fi
+

--- a/scripts/env/99-base.sh
+++ b/scripts/env/99-base.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# 
+# Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
+#
+# Copyright (c) 2015-2017, Gregory M. Kurtzer. All rights reserved.
+# 
+# Copyright (c) 2016-2017, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+# 
+# This software is licensed under a customized 3-clause BSD license.  Please
+# consult LICENSE.md file distributed with the sources of this project regarding
+# your rights to use or distribute this software.
+# 
+# NOTICE.  This Software was developed under funding from the U.S. Department of
+# Energy and the U.S. Government consequently retains certain rights. As such,
+# the U.S. Government has been granted for itself and others acting on its
+# behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
+# to reproduce, distribute copies to the public, prepare derivative works, and
+# perform publicly and display publicly, and to permit other to do so.
+# 
+# 
+
+
+if [ -z "$LD_LIBRARY_PATH" ]; then
+    LD_LIBRARY_PATH="/.singularity.d/libs"
+else
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/.singularity.d/libs"
+fi
+
+PS1="Singularity> "
+export LD_LIBRARY_PATH PS1

--- a/scripts/env/99-runtimevars.sh
+++ b/scripts/env/99-runtimevars.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright (c) 2017-2018, SyLabs, Inc. All rights reserved.
+#
+# This software is licensed under a customized 3-clause BSD license.  Please
+# consult LICENSE.md file distributed with the sources of this project regarding
+# your rights to use or distribute this software.
+#
+#
+
+if [ -n "${SING_USER_DEFINED_PREPEND_PATH:-}" ]; then
+	PATH="${SING_USER_DEFINED_PREPEND_PATH}:${PATH}"
+fi
+
+if [ -n "${SING_USER_DEFINED_APPEND_PATH:-}" ]; then
+	PATH="${PATH}:${SING_USER_DEFINED_APPEND_PATH}"
+fi
+
+if [ -n "${SING_USER_DEFINED_PATH:-}" ]; then
+	PATH="${SING_USER_DEFINED_PATH}"
+fi
+
+unset SING_USER_DEFINED_PREPEND_PATH \
+	  SING_USER_DEFINED_APPEND_PATH \
+	  SING_USER_DEFINED_PATH
+
+export PATH


### PR DESCRIPTION
This will update docker2singularity to work with v3.1. This means a change of base (golang with docker) along with adding the static files (e.g., the env folder, actions) that are normally generated on the fly by Singularity. These are technically written over by Singularity when it builds, but still needed when we customize the content there from docker. We also add in support for WORKDIR, and fix a bug with --writable being spelled wrong.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>