### PR TITLE
Fix for issue #66 preventing access to a container as a non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you want a legacy version, see the following other branches:
  - [v2.5](https://github.com/singularityware/docker2singularity/tree/v2.5): Version 2.5.1 of Singularity. Same as 2.4 but with many bug fixes.
  - [v2.6](https://github.com/singularityware/docker2singularity/tree/v2.6): Version 2.6 of Singularity.
 
-Intermediate versions built on [Docker Hub](https://hub.docker.com/r/singularityware/docker2singularity/tags/). A tag with prefix `v` corresponds to a release of the Singularity software, while the others are in reference to releases of Docker.
+Intermediate versions built on [Docker Hub](https://hub.docker.com/r/singularityware/docker2singularity/tags/). A tag with prefix `v` corresponds to a release of the Singularity software, while the others are in reference to releases of Docker. Previously used [scripts](https://github.com/singularityware/docker2singularity/tree/master/scripts), including environment and action files, are provided in this repository for reference.
 
 ## Requirements
 

--- a/docker2singularity.sh
+++ b/docker2singularity.sh
@@ -270,8 +270,11 @@ chmod +x $build_sandbox/.singularity.d/runscript;
 echo "(5/10) Setting ENV variables..."
 
 # First add templates for actions and env
-cp -R /scripts/env $build_sandbox/.singularity.d/
-cp -R /scripts/actions $build_sandbox/.singularity.d/
+## Removed to avoid permissions issue with scripts (see #66)
+## cp -R /scripts/env $build_sandbox/.singularity.d/
+## cp -R /scripts/actions $build_sandbox/.singularity.d/
+# Create env scripts directory
+mkdir $build_sandbox/.singularity.d/env; chmod 755 $build_sandbox/.singularity.d/env
 
 # Then customize by adding Docker variables
 docker run --rm --entrypoint="/usr/bin/env" $image > $TMPDIR/docker_environment

--- a/docker2singularity.sh
+++ b/docker2singularity.sh
@@ -269,12 +269,10 @@ chmod +x $build_sandbox/.singularity.d/runscript;
 
 echo "(5/10) Setting ENV variables..."
 
-# First add templates for actions and env
-## Removed to avoid permissions issue with scripts (see #66)
-## cp -R /scripts/env $build_sandbox/.singularity.d/
-## cp -R /scripts/actions $build_sandbox/.singularity.d/
+# Removed copying of template files to avoid scripts permissions issue (see #66)
 # Create env scripts directory
-mkdir $build_sandbox/.singularity.d/env; chmod 755 $build_sandbox/.singularity.d/env
+mkdir -p $build_sandbox/.singularity.d/env
+chmod 755 $build_sandbox/.singularity.d/env
 
 # Then customize by adding Docker variables
 docker run --rm --entrypoint="/usr/bin/env" $image > $TMPDIR/docker_environment


### PR DESCRIPTION
This PR fixes the problem described in issue #66 where the scripts placed `/.singularity.d/env/` in a singularity image generated from a docker image have permissions that only permit access by the root user.

This meant that the resulting image could only be run using `singularity exec` by a root user.

This PR fixes the issue meaning that generated singularity images can be run by a non-root user (subject to permissions of the files in the original container allowing this).